### PR TITLE
Add Travis CI to do automated testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+group: travis_latest
+language: python
+cache: pip
+python:
+    - 3.6
+    #- nightly
+    #- pypy3
+matrix:
+    allow_failures:
+        - python: nightly
+        - python: pypy3
+install:
+    #- pip install -r requirements.txt
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # pytest --capture=sys  # add other tests here
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
[Flake8](http://flake8.pycqa.org) tests can help to find Python syntax errors, undefined names, and other code quality issues.  [Travis CI](https://travis-ci.org) is a framework for running flake8 and other tests which is free for open source projects like this one.  The owner of the this repo would need to go to https://travis-ci.org/profile and flip the repository switch __on__ to enable free automated flake8 testing of each pull request.

flake8 testing of https://github.com/minimaxir/person-blocker on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./coco.py:108:16: F821 undefined name 'COCO'
        coco = COCO("{}/annotations/instances_{}{}.json".format(dataset_dir, subset, year))
               ^
./coco.py:288:20: F821 undefined name 'maskUtils'
            rles = maskUtils.frPyObjects(segm, height, width)
                   ^
./coco.py:289:19: F821 undefined name 'maskUtils'
            rle = maskUtils.merge(rles)
                  ^
./coco.py:292:19: F821 undefined name 'maskUtils'
            rle = maskUtils.frPyObjects(segm, height, width)
                  ^
./coco.py:304:13: F821 undefined name 'maskUtils'
        m = maskUtils.decode(rle)
            ^
./coco.py:333:33: F821 undefined name 'maskUtils'
                "segmentation": maskUtils.encode(np.asfortranarray(mask))
                                ^
./coco.py:378:16: F821 undefined name 'COCOeval'
    cocoEval = COCOeval(coco, coco_results, eval_type)
               ^
7     F821 undefined name 'COCO'
```