### PR TITLE
Add a Dockerfile for running script as a docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+example_output

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+
+RUN apt-get update -qq && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -qq \
+		python3-tk \
+		xvfb \
+		curl && \
+	curl -OJL https://github.com/matterport/Mask_RCNN/releases/download/v2.0/mask_rcnn_coco.h5 && \
+	pip install --no-cache-dir -r requirements.txt && \
+	apt-get remove --purge -qq curl && \
+	apt-get autoremove --purge -qq && \
+	apt-get clean -qq && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /init /root/.cache
+
+COPY . .
+
+WORKDIR /data
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["-n"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+xvfb-run python -W ignore /app/person_blocker.py -m /app/mask_rcnn_coco.h5 "$@"


### PR DESCRIPTION
This PR adds a Dockerfile and supporting files which allows the project to be built and run as a docker container.

By packaging this project as a portable docker image, it means users won't need to install and configure the script's various dependencies.

### Build

To build the docker image:

```
docker build -t person-blocker .
```

### Run

To run the docker image:

```
docker run --rm person-blocker
```

When run without arguments, it will run `person-blocker -n` (i.e. prints the class options for objects, then exits.)

To run the script against images, it's necessary to mount a host directory as a volume in the container. This must be mounted to `/data` inside the container. For example:

```
docker run --rm -v ~/Pictures/:/data person-blocker -i example.jpg
```

This will mount `~/Pictures/` from the host onto the container, and `person-blocker` will run against the image `~/Pictures/example.jpg`.

Output images will be saved back to the mount directory, so will be available at `~/Pictures/person_blocked.png` and `~/Pictures/person_blocked.gif`.

### `docker-entrypoint.sh`

This file is executed by docker when the image is run. Things to note about this file:

- Python is configured to ignore warnings (since there are some warnings thrown by this script, which can be safely ignored by an end user). This is achieved using `python -W ignore`.
- `xvfb-run` is used to execute the python script inside a virtual X server. An X server is required for the script to run, but since we don't actually have one running inside docker I'm using `xvfb`.
- The only argument which is hardcoded to `person_blocker.py` is `-m`. This is because the pretrained COCO model is downloaded during `docker build` and saved to the image. So no need to download this at runtime.
- All other arguments given at `docker run` are passed through to `person_blocker.py`.

### Docker Hub

If this PR is merged in, it will be possible to register it over on Docker Hub so the script can be served as a pre-built image for end users to consume. Although this is optional, it would mean that users wouldn't need to clone this git repository and build the image themselves. Instead they'd be able to simply pull the image from Docker Hub and execute is straight away.

Docker Hub integrates with GitHub and supports automated builds – so every time you update the script, a Docker Hub's CI system builds and publishes the updated image. [More details about how to set that up.](https://docs.docker.com/docker-hub/github/)