### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
+tensorflow
+keras==2.1.6
 h5py
 imageio
 ipython
-keras
 scipy
 scikit-image
-tensorflow


### PR DESCRIPTION
Tensorflow must be installed before keras. Install keras==2.1.6 to resolve "AttributeError: module 'keras.engine.topology' has no attribute 'load_weights_from_hdf5_group_by_name'".